### PR TITLE
Fix display of default 503 error page

### DIFF
--- a/templates/maintenance.conf
+++ b/templates/maintenance.conf
@@ -1,9 +1,9 @@
 location ~* ^(.*)$ {
   root {APP_ROOT}/maintenance/;
-  try_files $uri =503;
+  try_files $uri =533;
 }
 
-error_page 503 @maintenance;
+error_page 533 =503 @maintenance;
 
 location @maintenance {
   root {APP_ROOT}/maintenance/;


### PR DESCRIPTION
Fixes bug reported in issue #16. The nginx configuration in the dokku captures a 503 error and the maintenance page is not displayed. The solution is to return error 533 (unused code in dokku config) instead of 503 in maintenance mode, then capture this error, change the code to 503 and return the maintenance page.