### PR TITLE
Mention `maintenance:report`  instead of `maintenance` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ sudo dokku plugin:install https://github.com/dokku/dokku-maintenance.git mainten
 
 ```
 $ dokku help
-    maintenance <app>                               Display the current maintenance status of app
+    maintenance <app>                               Display the list of commands
     maintenance:custom-page <app>                   Imports a tarball from stdin; should contain at least maintenance.html
     maintenance:disable <app>                       Disable app maintenance mode
     maintenance:enable <app>                        Enable app maintenance mode
+    maintenance:report [<app>] [<flag>]             Displays a maintenance report for one or more apps
 ```
 
 ## usage
@@ -29,8 +30,8 @@ $ dokku help
 Check maintenance status of my-app
 
 ```
-# dokku maintenance my-app            # Server side
-$ ssh dokku@server maintenance my-app # Client side
+# dokku maintenance:report my-app            # Server side
+$ ssh dokku@server maintenance:report my-app # Client side
 
 -----> Maintenance status of my-app:
        off


### PR DESCRIPTION
Hey @josegonzalez,

Thanks so much for dokku! I just discovered it a few days ago and am wondering how I missed this all my life 😂 it literally solves all my deployment problems and makes me as excited about deploying stuff like Heroku did ~10 years ago, except that it's free! Donated $10 do you recently, hope you can buy yourself a coffee / beer / lunch etc. :)

I just came across a small issue when reading the readme for this plugin - the command `maintenance` has probably been renamed to `maintenance:report` for getting the maintenance status of apps.

So I went ahead and fixed it. Hope this makes sense!

Oliver