### PR TITLE
fix: serve the maintenance page from nginx's docroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ COMPOSE := DOKKU_VERSION=$(DOKKU_VERSION) MAINTEST_HOST_DIR=$(MAINTEST_HOST_DIR)
 COMPOSE_COMPOSE_MODE := $(COMPOSE) --profile compose-mode
 COMPOSE_EXEC_DOKKU := $(COMPOSE) exec -T dokku
 
-PLUGIN_BASH_FILES := command-functions commands config help-functions internal-functions report \
+PLUGIN_BASH_FILES := command-functions commands config help-functions install internal-functions report \
 	$(wildcard subcommands/*) \
 	tests/setup.sh tests/setup-native.sh tests/test_helper.bash \
 	tests/lego/challtestsrv-dns.sh tests/pebble/init-cert.sh

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ image.jpg
 
 You have to provide at least a maintenance.html page but you can provide images, css, custom font, etc. if you want. Just write absolute paths in your html and not relative ones (so to serve image.jpg which is at the same level than your maintenance.html page you’ll write “/image.jpg” instead of “./image.jpg” or “image.jpg”).
 
+## maintenance page storage
+
+The maintenance page and any custom assets are stored under nginx's docroot at `/var/www/dokku-maintenance/<app>` and served from there. Earlier versions served them out of `/home/dokku/<app>`, which nginx workers cannot read on hardened installs where `/home/dokku` is `0700`, producing a `403` instead of the maintenance page. Upgrading the plugin automatically relocates the assets for any app that already has maintenance mode enabled, so no manual action is required.
+
 ## let's encrypt
 
 Maintenance mode leaves the `/.well-known/acme-challenge` path untouched, so [dokku-letsencrypt](https://github.com/dokku/dokku-letsencrypt) can still complete the ACME HTTP-01 challenge. Certificate issuance and renewal continue to work while an app is in maintenance mode.

--- a/command-functions
+++ b/command-functions
@@ -84,10 +84,11 @@ cmd-maintenance-custom-page() {
   pushd "$TEMP_DIR" >/dev/null
   tar xvf - <&0
   [[ ! -f "$TEMP_DIR/maintenance.html" ]] && dokku_log_fail "Tar archive missing maintenance.html"
-  mkdir -p "$DOKKU_ROOT/$APP/maintenance"
+  mkdir -p "$MAINTENANCE_DATA_ROOT/$APP"
 
   # shellcheck disable=SC2086
-  mv $TEMP_DIR/* "$DOKKU_ROOT/$APP/maintenance"
+  mv $TEMP_DIR/* "$MAINTENANCE_DATA_ROOT/$APP"
+  fn-maintenance-fix-permissions "$MAINTENANCE_DATA_ROOT/$APP"
   popd &>/dev/null || pushd "/tmp" >/dev/null
   dokku_log_verbose "Done"
 }
@@ -139,7 +140,7 @@ cmd-maintenance-enable() {
 
   declare APP="$1"
   local NGINX_CONF_D="$DOKKU_ROOT/$APP/nginx.conf.d"
-  local MAINTENANCE_APP_D="$DOKKU_ROOT/$APP/maintenance"
+  local MAINTENANCE_APP_D="$MAINTENANCE_DATA_ROOT/$APP"
 
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
@@ -153,12 +154,13 @@ cmd-maintenance-enable() {
   [[ -d "$NGINX_CONF_D" ]] || mkdir "$NGINX_CONF_D"
 
   if [[ ! -d "$MAINTENANCE_APP_D" ]]; then
-    mkdir "$MAINTENANCE_APP_D"
+    mkdir -p "$MAINTENANCE_APP_D"
     cp "$MAINTENANCE_PLUGIN_ROOT/templates/maintenance.html" "$MAINTENANCE_APP_D"
   fi
+  fn-maintenance-fix-permissions "$MAINTENANCE_APP_D"
 
   cp "$MAINTENANCE_PLUGIN_ROOT/templates/maintenance.conf" "$NGINX_CONF_D"
-  sed -i "s,{APP_ROOT},$DOKKU_ROOT/$APP," "$NGINX_CONF_D/maintenance.conf"
+  sed -i "s,{MAINTENANCE_ROOT},$MAINTENANCE_APP_D," "$NGINX_CONF_D/maintenance.conf"
   validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
   dokku_log_verbose "Done"
 }

--- a/config
+++ b/config
@@ -4,6 +4,11 @@ export PLUGIN_VARIABLE="MAINTENANCE"
 export PLUGIN_BASE_PATH="$PLUGIN_PATH"
 export MAINTENANCE_PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Maintenance assets are served out of nginx's docroot rather than
+# /home/dokku/<app>, which nginx workers cannot traverse on hardened installs
+# (see issue #19). Overridable so the test suite can point it elsewhere.
+export MAINTENANCE_DATA_ROOT="${MAINTENANCE_DATA_ROOT:-/var/www/dokku-maintenance}"
+
 if [[ -n $DOKKU_API_VERSION ]]; then
   export PLUGIN_BASE_PATH="$PLUGIN_ENABLED_PATH"
 fi

--- a/install
+++ b/install
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/maintenance/config"
+source "$PLUGIN_AVAILABLE_PATH/maintenance/internal-functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/nginx-vhosts/functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+fn-maintenance-install() {
+  declare desc="relocate maintenance assets into nginx's docroot on install/upgrade (issue #19)"
+
+  # /var/www is root-owned, so the base docroot must be created here (the install
+  # trigger runs as root) and chowned to dokku, letting later (dokku-user)
+  # enable/custom-page calls create per-app subdirs under it. World bits keep it
+  # nginx-readable.
+  mkdir -p "$MAINTENANCE_DATA_ROOT"
+  chown dokku:dokku "$MAINTENANCE_DATA_ROOT"
+  chmod 755 "$MAINTENANCE_DATA_ROOT"
+
+  # Iterate EVERY app, unfiltered. dokku_apps "false" returns the full app list -
+  # the "false" arg does not filter the set, it only suppresses the "you haven't
+  # deployed any apps" error so a fresh dokku with zero apps does not abort the
+  # install trigger. (Same idiom as core's nginx-vhosts/install migration.)
+  local app migrated=false
+  for app in $(dokku_apps "false" 2>/dev/null); do
+    if fn-maintenance-migrate-app "$app"; then
+      dokku_log_info1 "Relocated maintenance assets for $app"
+      chown -R dokku:dokku "$MAINTENANCE_DATA_ROOT/$app"
+      migrated=true
+      APP="$app" restart_nginx "$app" || true # reload; never abort install
+    fi
+  done
+
+  [[ "$migrated" == "true" ]] && dokku_log_verbose "Maintenance asset migration complete"
+  return 0
+}
+
+fn-maintenance-install "$@"

--- a/internal-functions
+++ b/internal-functions
@@ -15,3 +15,41 @@ fn-maintenance-enabled() {
 
   echo "$enabled"
 }
+
+fn-maintenance-fix-permissions() {
+  declare desc="ensure nginx workers can traverse and read the maintenance assets"
+  declare MAINTENANCE_APP_D="$1"
+  # 0755 dirs, 0644 files so the nginx user (www-data/nginx) can read the page
+  # even when the install's umask is tighter than 022.
+  find "$MAINTENANCE_APP_D" -type d -exec chmod 755 {} +
+  find "$MAINTENANCE_APP_D" -type f -exec chmod 644 {} +
+  # On SELinux hosts, files moved into /var/www may keep a non-web context;
+  # restore the web-content context so nginx is allowed to read them.
+  if command -v restorecon >/dev/null 2>&1; then
+    restorecon -R "$MAINTENANCE_APP_D" >/dev/null 2>&1 || true
+  fi
+}
+
+fn-maintenance-migrate-app() {
+  declare desc="migrate a single app's maintenance assets to the data root (issue #19)"
+  declare APP="$1"
+  local legacy_dir="$DOKKU_ROOT/$APP/maintenance"
+  local new_dir="$MAINTENANCE_DATA_ROOT/$APP"
+  local conf="$DOKKU_ROOT/$APP/nginx.conf.d/maintenance.conf"
+
+  # Relocate the app's assets out of the legacy /home/dokku/<app>/maintenance dir
+  # into the nginx-readable data root and re-point its include if present.
+  # Idempotent: a no-op once the legacy dir is gone. Returns 0 if it migrated.
+  [[ -d "$legacy_dir" ]] || return 1
+
+  mkdir -p "$new_dir"
+  cp -a "$legacy_dir/." "$new_dir/"
+  fn-maintenance-fix-permissions "$new_dir"
+  [[ -f "$new_dir/maintenance.html" ]] && rm -rf "$legacy_dir"
+
+  if [[ -f "$conf" ]]; then
+    cp "$MAINTENANCE_PLUGIN_ROOT/templates/maintenance.conf" "$conf"
+    sed -i "s,{MAINTENANCE_ROOT},$new_dir," "$conf"
+  fi
+  return 0
+}

--- a/templates/maintenance.conf
+++ b/templates/maintenance.conf
@@ -1,11 +1,11 @@
 location ~* ^(?!/\.well-known/acme-challenge).*$ {
-  root {APP_ROOT}/maintenance/;
+  root {MAINTENANCE_ROOT};
   try_files $uri =533;
 }
 
 error_page 533 =503 @maintenance;
 
 location @maintenance {
-  root {APP_ROOT}/maintenance/;
+  root {MAINTENANCE_ROOT};
   rewrite ^(.*)$ /maintenance.html break;
 }

--- a/tests/maintenance_custom_page.bats
+++ b/tests/maintenance_custom_page.bats
@@ -53,7 +53,20 @@ teardown() {
   run dokku maintenance:custom-page "$APP" <"$tarball"
   [ "$status" -eq 0 ]
   $SUDO test -f "$(maintenance_page_path "$APP")"
-  $SUDO test -f "/home/dokku/$APP/maintenance/style.css"
+  $SUDO test -f "$(maintenance_app_dir "$APP")/style.css"
+}
+
+@test "maintenance:custom-page writes an nginx-readable page (issue #19)" {
+  local tarball="${BATS_TEST_TMPDIR}/perms.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page"
+  run dokku maintenance:custom-page "$APP" <"$tarball"
+  [ "$status" -eq 0 ]
+  local page pperms
+  page="$(maintenance_page_path "$APP")"
+  [[ "$page" != /home/dokku/* ]]
+  # other-read bit (index 7 of the `-rwxrwxrwx` string) must be set
+  pperms="$($SUDO stat -c '%A' "$page")"
+  [ "${pperms:7:1}" = "r" ]
 }
 
 @test "maintenance:enable preserves a previously imported custom page" {

--- a/tests/maintenance_enable.bats
+++ b/tests/maintenance_enable.bats
@@ -29,8 +29,28 @@ teardown() {
   [[ "$output" == *"Enabling maintenance mode for $APP"* ]]
   $SUDO test -f "$(maintenance_conf_path "$APP")"
   $SUDO test -f "$(maintenance_page_path "$APP")"
-  $SUDO grep -q "/home/dokku/$APP/maintenance" "$(maintenance_conf_path "$APP")"
-  ! $SUDO grep -q '{APP_ROOT}' "$(maintenance_conf_path "$APP")"
+  $SUDO grep -q "$(maintenance_app_dir "$APP")" "$(maintenance_conf_path "$APP")"
+  ! $SUDO grep -q '{MAINTENANCE_ROOT}' "$(maintenance_conf_path "$APP")"
+}
+
+@test "maintenance:enable serves the page from an nginx-readable location (issue #19)" {
+  run dokku maintenance:enable "$APP"
+  [ "$status" -eq 0 ]
+  # The 403 was caused by nginx workers (www-data/nginx) being unable to
+  # traverse /home/dokku (0700 on hardened installs) to read the page. The fix
+  # serves it from nginx's docroot instead, so the assets must live outside
+  # /home/dokku and be world-traversable/readable.
+  local page dir dperms pperms
+  page="$(maintenance_page_path "$APP")"
+  dir="$(maintenance_app_dir "$APP")"
+  [[ "$page" != /home/dokku/* ]]
+  # In the `-rwxrwxrwx` string from `stat -c %A`, index 7 is other-read and
+  # index 9 is other-execute. The dir must be world-traversable (o+x) and the
+  # page world-readable (o+r) for the nginx worker to serve it.
+  dperms="$($SUDO stat -c '%A' "$dir")"
+  pperms="$($SUDO stat -c '%A' "$page")"
+  [ "${dperms:9:1}" = "x" ]
+  [ "${pperms:7:1}" = "r" ]
 }
 
 @test "maintenance:enable carves the acme-challenge path out of the catch-all" {

--- a/tests/maintenance_migrate.bats
+++ b/tests/maintenance_migrate.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Covers the issue #19 upgrade migration. On plugin install/upgrade the `install`
+# trigger loops over every app and calls fn-maintenance-migrate-app, relocating
+# assets out of the legacy /home/dokku/<app>/maintenance dir (which nginx workers
+# cannot read on hardened installs) into nginx's docroot and re-pointing the
+# include. The trigger itself needs dokku's full runtime env + root + an nginx
+# reload, so we exercise the migration function directly against a sandboxed
+# DOKKU_ROOT and docroot - the trigger is a thin loop over this function.
+
+load 'test_helper'
+
+setup() {
+  PLUGIN_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  CORE_AVAILABLE_PATH="${PLUGIN_CORE_AVAILABLE_PATH:-/var/lib/dokku/core-plugins/available}"
+  [[ -f "$CORE_AVAILABLE_PATH/common/property-functions" ]] ||
+    skip "dokku core plugins not available at $CORE_AVAILABLE_PATH"
+
+  # Fully sandboxed paths so the migration never touches the real host.
+  SANDBOX_DOKKU_ROOT="${BATS_TEST_TMPDIR}/home-dokku"
+  SANDBOX_DATA_ROOT="${BATS_TEST_TMPDIR}/var-www"
+  mkdir -p "$SANDBOX_DOKKU_ROOT" "$SANDBOX_DATA_ROOT"
+}
+
+# Stage a pre-upgrade layout for $1: assets under DOKKU_ROOT/<app>/maintenance and
+# a legacy include whose `root` points at that /home/dokku path.
+stage_legacy_app() {
+  local app="$1" marker="$2"
+  mkdir -p "$SANDBOX_DOKKU_ROOT/$app/maintenance" "$SANDBOX_DOKKU_ROOT/$app/nginx.conf.d"
+  echo "$marker" >"$SANDBOX_DOKKU_ROOT/$app/maintenance/maintenance.html"
+  cp "$PLUGIN_ROOT/templates/maintenance.conf" "$SANDBOX_DOKKU_ROOT/$app/nginx.conf.d/maintenance.conf"
+  sed -i "s,{MAINTENANCE_ROOT},$SANDBOX_DOKKU_ROOT/$app/maintenance," \
+    "$SANDBOX_DOKKU_ROOT/$app/nginx.conf.d/maintenance.conf"
+}
+
+# Run fn-maintenance-migrate-app in a subshell with the plugin functions sourced
+# and the sandboxed paths in the environment.
+run_migrate() {
+  local app="$1"
+  DOKKU_ROOT="$SANDBOX_DOKKU_ROOT" \
+    MAINTENANCE_DATA_ROOT="$SANDBOX_DATA_ROOT" \
+    MAINTENANCE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    PLUGIN_CORE_AVAILABLE_PATH="$CORE_AVAILABLE_PATH" \
+    run bash -c "source '$PLUGIN_ROOT/config'; source '$PLUGIN_ROOT/internal-functions'; fn-maintenance-migrate-app '$app'"
+}
+
+@test "migration relocates legacy assets and repoints the include" {
+  stage_legacy_app "migrate-app" "legacy-marker-page"
+
+  run_migrate "migrate-app"
+  [ "$status" -eq 0 ]
+
+  # legacy dir is gone
+  [ ! -d "$SANDBOX_DOKKU_ROOT/migrate-app/maintenance" ]
+  # the page (marker intact) now lives in the docroot and is world-readable
+  grep -q "legacy-marker-page" "$SANDBOX_DATA_ROOT/migrate-app/maintenance.html"
+  local pperms
+  pperms="$(stat -c '%A' "$SANDBOX_DATA_ROOT/migrate-app/maintenance.html")"
+  [ "${pperms:7:1}" = "r" ]
+  # the include now points at the docroot, and the old /home/dokku path is gone
+  grep -q "$SANDBOX_DATA_ROOT/migrate-app" "$SANDBOX_DOKKU_ROOT/migrate-app/nginx.conf.d/maintenance.conf"
+  ! grep -q "$SANDBOX_DOKKU_ROOT/migrate-app/maintenance" "$SANDBOX_DOKKU_ROOT/migrate-app/nginx.conf.d/maintenance.conf"
+}
+
+@test "migration preserves custom pages and extra assets" {
+  stage_legacy_app "migrate-custom" "custom-marker-page"
+  echo "body {}" >"$SANDBOX_DOKKU_ROOT/migrate-custom/maintenance/style.css"
+
+  run_migrate "migrate-custom"
+  [ "$status" -eq 0 ]
+
+  grep -q "custom-marker-page" "$SANDBOX_DATA_ROOT/migrate-custom/maintenance.html"
+  [ -f "$SANDBOX_DATA_ROOT/migrate-custom/style.css" ]
+}
+
+@test "migration is a no-op when there is nothing to migrate" {
+  # no legacy dir staged for this app
+  run_migrate "migrate-absent"
+  [ "$status" -ne 0 ]
+  [ ! -d "$SANDBOX_DATA_ROOT/migrate-absent" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -34,9 +34,25 @@ maintenance_conf_path() {
   echo "/home/dokku/${app}/nginx.conf.d/maintenance.conf"
 }
 
+maintenance_data_root() {
+  echo "/var/www/dokku-maintenance"
+}
+
+maintenance_app_dir() {
+  local app="$1"
+  echo "$(maintenance_data_root)/${app}"
+}
+
 maintenance_page_path() {
   local app="$1"
-  echo "/home/dokku/${app}/maintenance/maintenance.html"
+  echo "$(maintenance_app_dir "$app")/maintenance.html"
+}
+
+# Legacy (pre-issue-#19) asset location under /home/dokku, used by the migration
+# test to stage a pre-upgrade layout.
+maintenance_legacy_dir() {
+  local app="$1"
+  echo "/home/dokku/${app}/maintenance"
 }
 
 # Builds a tarball at $1 containing the remaining arguments, given as


### PR DESCRIPTION
Enabling maintenance mode returned a `403` instead of the maintenance page on installs where the nginx worker cannot traverse `/home/dokku`, which is `0700` on hardened systems such as Debian 12. The page and any custom assets are now stored under nginx's docroot at `/var/www/dokku-maintenance` and served from there so any nginx user can read them, and apps that already have maintenance mode enabled are relocated automatically when the plugin is upgraded.

Fixes #19.