### PR TITLE
feat: add --format json support to maintenance:report

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -8,3 +8,5 @@ disable=SC2068
 disable=SC2086
 # SC2155: declare-and-assign is the established style here
 disable=SC2155
+# SC2178: bash nameref via `local -n` is intentionally an array reference
+disable=SC2178

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ dokku help
     maintenance:custom-page <app>                   Imports a tarball from stdin; should contain at least maintenance.html
     maintenance:disable <app>                       Disable app maintenance mode
     maintenance:enable <app>                        Enable app maintenance mode
-    maintenance:report [<app>] [<flag>]             Displays a maintenance report for one or more apps
+    maintenance:report [<app>] [<flag>] [--format stdout|json]   Displays a maintenance report for one or more apps
 ```
 
 ## usage
@@ -35,6 +35,15 @@ $ ssh dokku@server maintenance:report my-app # Client side
 
 -----> Maintenance status of my-app:
        off
+```
+
+The report can also be emitted as JSON for programmatic use:
+
+```
+# dokku maintenance:report my-app --format json            # Server side
+$ ssh dokku@server maintenance:report my-app --format json # Client side
+
+{"enabled":"false"}
 ```
 
 Enable maintenance mode for my-app

--- a/command-functions
+++ b/command-functions
@@ -11,7 +11,10 @@ cmd-maintenance-report() {
   declare desc="displays a maintenance report for one or more apps"
   declare cmd="maintenance:report"
   [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1" INFO_FLAG="$2"
+  fn-maintenance-report-parse-args "$@"
+  set -- "${REPORT_ARGS[@]}"
+
+  declare APP="${1:-}" INFO_FLAG="${2:-}"
   local INSTALLED_APPS
   INSTALLED_APPS=$(dokku_apps)
 
@@ -20,31 +23,54 @@ cmd-maintenance-report() {
     APP=""
   fi
 
+  if [[ "$REPORT_IS_GLOBAL" == "true" ]]; then
+    APP="--global"
+  fi
+
   if [[ -z "$APP" ]] && [[ -z "$INFO_FLAG" ]]; then
     INFO_FLAG="true"
   fi
 
-  if [[ -z "$APP" ]]; then
+  if [[ "$APP" == "--global" ]]; then
+    cmd-maintenance-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
+  elif [[ -z "$APP" ]]; then
     for app in $INSTALLED_APPS; do
-      cmd-maintenance-report-single "$app" "$INFO_FLAG" | tee || true
+      cmd-maintenance-report-single "$app" "$INFO_FLAG" "$REPORT_FORMAT" | tee || true
     done
   else
-    cmd-maintenance-report-single "$APP" "$INFO_FLAG"
+    cmd-maintenance-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
   fi
 }
 
 cmd-maintenance-report-single() {
-  declare APP="$1" INFO_FLAG="$2"
+  declare APP="$1" INFO_FLAG="$2" FORMAT="${3:-stdout}"
   if [[ "$INFO_FLAG" == "true" ]]; then
     INFO_FLAG=""
   fi
-  verify_app_name "$APP"
+  if [[ "$APP" != "--global" ]]; then
+    verify_app_name "$APP"
+  fi
   local flag_map=(
     "--maintenance-enabled: $(fn-maintenance-enabled "$APP")"
   )
 
+  if [[ "$APP" == "--global" ]]; then
+    fn-maintenance-report-filter-global flag_map
+  fi
+
+  fn-maintenance-report-validate-format "$FORMAT" "$INFO_FLAG"
+
+  if [[ "$FORMAT" == "json" ]]; then
+    fn-maintenance-report-emit-json flag_map
+    return
+  fi
+
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2_quiet "${APP} maintenance information"
+    if [[ "$APP" == "--global" ]]; then
+      dokku_log_info2_quiet "global maintenance information"
+    else
+      dokku_log_info2_quiet "${APP} maintenance information"
+    fi
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-30s %-25s" "${key^}" "${flag#*: }")"

--- a/help-functions
+++ b/help-functions
@@ -30,6 +30,6 @@ fn-help-content() {
     maintenance:custom-page <app>, Imports a tarball from stdin; should contain at least maintenance.html
     maintenance:disable <app>, Disable app maintenance mode
     maintenance:enable <app>, Enable app maintenance mode
-    maintenance:report [<app>] [<flag>], Displays an maintenance report for one or more apps
+    maintenance:report [<app>] [<flag>] [--format stdout|json], Displays a maintenance report for one or more apps
 help_content
 }

--- a/internal-functions
+++ b/internal-functions
@@ -53,3 +53,63 @@ fn-maintenance-migrate-app() {
   fi
   return 0
 }
+
+fn-maintenance-report-parse-args() {
+  declare desc="strip --format and --global from a report invocation"
+  REPORT_FORMAT="stdout"
+  REPORT_IS_GLOBAL="false"
+  REPORT_ARGS=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --format)
+        REPORT_FORMAT="$2"
+        shift 2
+        ;;
+      --global)
+        REPORT_IS_GLOBAL="true"
+        shift
+        ;;
+      *)
+        REPORT_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+fn-maintenance-report-validate-format() {
+  declare desc="reject --format when combined with an info flag"
+  declare FORMAT="$1" INFO_FLAG="$2"
+  if [[ "$FORMAT" != "stdout" ]] && [[ -n "$INFO_FLAG" ]]; then
+    dokku_log_fail "--format flag cannot be specified when specifying an info flag"
+  fi
+}
+
+fn-maintenance-report-filter-global() {
+  declare desc="rewrite flag_map keeping only --maintenance-global-* entries"
+  declare flag_map_name="$1"
+  local -n flag_map_ref="$flag_map_name"
+  local filtered=()
+  local flag key
+  for flag in "${flag_map_ref[@]}"; do
+    key="$(echo "$flag" | cut -d':' -f1)"
+    if [[ "$key" == *"-global-"* ]]; then
+      filtered+=("$flag")
+    fi
+  done
+  flag_map_ref=("${filtered[@]}")
+}
+
+fn-maintenance-report-emit-json() {
+  declare desc="emit a flag_map as a JSON object, stripping the --maintenance- key prefix"
+  declare flag_map_name="$1"
+  local -n flag_map_ref="$flag_map_name"
+  local json_output="{}"
+  local flag key value
+  for flag in "${flag_map_ref[@]}"; do
+    key="$(echo "$flag" | cut -d':' -f1 | sed 's/^--maintenance-//')"
+    value="$(echo "$flag" | cut -d':' -f2- | sed 's/^ //')"
+    json_output="$(echo "$json_output" | jq -c --arg key "$key" --arg value "$value" '. + {($key): $value}')"
+  done
+  echo "$json_output"
+}

--- a/tests/maintenance_report.bats
+++ b/tests/maintenance_report.bats
@@ -44,6 +44,30 @@ teardown() {
   [ "$output" = "true" ]
 }
 
+@test "maintenance:report --format json emits a json object" {
+  run dokku maintenance:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"enabled":"false"'* ]]
+
+  dokku maintenance:enable "$APP"
+
+  run dokku maintenance:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"enabled":"true"'* ]]
+}
+
+@test "maintenance:report --format json rejects an info flag" {
+  run dokku maintenance:report "$APP" --format json --maintenance-enabled
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--format flag cannot be specified when specifying an info flag"* ]]
+}
+
+@test "maintenance:report --global --format json returns a json object" {
+  run dokku maintenance:report --global --format json
+  [ "$status" -eq 0 ]
+  [ "$output" = "{}" ]
+}
+
 @test "maintenance:report rejects an invalid flag" {
   run dokku maintenance:report "$APP" --invalid-flag
   [ "$status" -ne 0 ]


### PR DESCRIPTION
Aligns `maintenance:report` with the report output standardization used across Dokku and its plugins, adding `--format stdout|json` and `--global` support so the report can be consumed programmatically while leaving the existing human-readable output unchanged.