### PR TITLE
feat: expose custom-page checksum in maintenance:report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ COMPOSE := DOKKU_VERSION=$(DOKKU_VERSION) MAINTEST_HOST_DIR=$(MAINTEST_HOST_DIR)
 COMPOSE_COMPOSE_MODE := $(COMPOSE) --profile compose-mode
 COMPOSE_EXEC_DOKKU := $(COMPOSE) exec -T dokku
 
-PLUGIN_BASH_FILES := command-functions commands config help-functions install internal-functions report \
+PLUGIN_BASH_FILES := command-functions commands config help-functions install internal-functions post-delete report \
 	$(wildcard subcommands/*) \
 	tests/setup.sh tests/setup-native.sh tests/test_helper.bash \
 	tests/lego/challtestsrv-dns.sh tests/pebble/init-cert.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ sudo dokku plugin:install https://github.com/dokku/dokku-maintenance.git mainten
 $ dokku help
     maintenance <app>                               Display the list of commands
     maintenance:custom-page <app>                   Imports a tarball from stdin; should contain at least maintenance.html
+    maintenance:custom-page-remove <app>            Removes a custom maintenance page and resets to the default page
     maintenance:disable <app>                       Disable app maintenance mode
     maintenance:enable <app>                        Enable app maintenance mode
     maintenance:report [<app>] [<flag>] [--format stdout|json]   Displays a maintenance report for one or more apps
@@ -43,8 +44,10 @@ The report can also be emitted as JSON for programmatic use:
 # dokku maintenance:report my-app --format json            # Server side
 $ ssh dokku@server maintenance:report my-app --format json # Client side
 
-{"enabled":"false"}
+{"enabled":"false","custom-page-sha256":""}
 ```
+
+The `custom-page-sha256` key is a content checksum of the app's current custom page (see [custom page checksum](#custom-page-checksum) below). It is empty until a custom page is imported.
 
 Enable maintenance mode for my-app
 
@@ -79,6 +82,35 @@ image.jpg
 ```
 
 You have to provide at least a maintenance.html page but you can provide images, css, custom font, etc. if you want. Just write absolute paths in your html and not relative ones (so to serve image.jpg which is at the same level than your maintenance.html page you’ll write “/image.jpg” instead of “./image.jpg” or “image.jpg”).
+
+Importing a custom page replaces the previously stored page in full, so files from an earlier upload are not left behind.
+
+Remove a custom page and reset to the default
+
+```
+# dokku maintenance:custom-page-remove my-app            # Server side
+$ ssh dokku@server maintenance:custom-page-remove my-app # Client side
+
+-----> Removing custom maintenance page for my-app...
+       done
+```
+
+Removing the custom page clears the stored `custom-page-sha256`. If maintenance mode is enabled at the time, the app immediately falls back to serving the default maintenance page.
+
+## custom page checksum
+
+`maintenance:report` exposes a `custom-page-sha256` key so tools that manage maintenance declaratively (for example [docket](https://github.com/dokku/docket)) can tell whether the stored page already matches the desired one and skip a redundant upload. The value is empty until a custom page is imported, and it is a checksum of the extracted page content rather than the uploaded tar (tar wrappers embed mtimes and entry ordering and are not byte-reproducible).
+
+The checksum is a canonical digest over every stored file: for each regular file, sorted by its path relative to the page directory, a line of `<sha256-of-contents>  <relative-path>` is emitted, and the sha256 of that stream is the reported value. A client can reproduce it over the source directory before uploading:
+
+```shell
+cd pagedir
+find . -type f | sed 's|^\./||' | LC_ALL=C sort | while IFS= read -r f; do
+  printf '%s  %s\n' "$(sha256sum "$f" | cut -d' ' -f1)" "$f"
+done | sha256sum | cut -d' ' -f1
+```
+
+Upgrading the plugin records the checksum for any app that already has a custom page, so the value is populated without re-uploading.
 
 ## maintenance page storage
 

--- a/command-functions
+++ b/command-functions
@@ -54,6 +54,10 @@ cmd-maintenance-report-single() {
     "--maintenance-enabled: $(fn-maintenance-enabled "$APP")"
   )
 
+  if [[ "$APP" != "--global" ]]; then
+    flag_map+=("--maintenance-custom-page-sha256: $(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$APP" "custom-page-sha256" "")")
+  fi
+
   if [[ "$APP" == "--global" ]]; then
     fn-maintenance-report-filter-global flag_map
   fi
@@ -112,10 +116,54 @@ cmd-maintenance-custom-page() {
   [[ ! -f "$TEMP_DIR/maintenance.html" ]] && dokku_log_fail "Tar archive missing maintenance.html"
   mkdir -p "$MAINTENANCE_DATA_ROOT/$APP"
 
+  # Replace any previously-stored page so the result is exactly this upload, not
+  # a merge with leftover files from a prior custom page or the default page.
+  find "$MAINTENANCE_DATA_ROOT/$APP" -mindepth 1 -delete
+
   # shellcheck disable=SC2086
   mv $TEMP_DIR/* "$MAINTENANCE_DATA_ROOT/$APP"
   fn-maintenance-fix-permissions "$MAINTENANCE_DATA_ROOT/$APP"
+  fn-plugin-property-write "$PLUGIN_COMMAND_PREFIX" "$APP" "custom-page-sha256" \
+    "$(fn-maintenance-custom-page-checksum "$MAINTENANCE_DATA_ROOT/$APP")"
   popd &>/dev/null || pushd "/tmp" >/dev/null
+  dokku_log_verbose "Done"
+}
+
+cmd-maintenance-custom-page-remove() {
+  declare desc="removes a custom maintenance page, resetting to the default page"
+  declare cmd="maintenance:custom-page-remove"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  # Support --app/$DOKKU_APP_NAME flag by reordering args into "$cmd $DOKKU_APP_NAME $@"
+  local argv=("$@")
+  [[ -n "$DOKKU_APP_NAME" ]] && set -- "$DOKKU_APP_NAME" $@
+  ##
+
+  declare APP="$1"
+  local NGINX_CONF_D="$DOKKU_ROOT/$APP/nginx.conf.d"
+  local MAINTENANCE_APP_D="$MAINTENANCE_DATA_ROOT/$APP"
+
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
+
+  if [[ -z "$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$APP" "custom-page-sha256" "")" ]]; then
+    dokku_log_info1 "No custom maintenance page set for $APP"
+    return
+  fi
+
+  dokku_log_info1 "Removing custom maintenance page for $APP..."
+  fn-plugin-property-delete "$PLUGIN_COMMAND_PREFIX" "$APP" "custom-page-sha256"
+  rm -rf "${MAINTENANCE_APP_D:?}"
+
+  # If maintenance is currently enabled, restore the default page so the app
+  # keeps serving a maintenance page from nginx's docroot (the include's `root`
+  # path is unchanged).
+  if [[ -f "$NGINX_CONF_D/maintenance.conf" ]]; then
+    mkdir -p "$MAINTENANCE_APP_D"
+    cp "$MAINTENANCE_PLUGIN_ROOT/templates/maintenance.html" "$MAINTENANCE_APP_D"
+    fn-maintenance-fix-permissions "$MAINTENANCE_APP_D"
+    validate_nginx "$APP" && restart_nginx "$APP" >/dev/null
+  fi
   dokku_log_verbose "Done"
 }
 

--- a/help-functions
+++ b/help-functions
@@ -28,6 +28,7 @@ fn-help-content() {
   declare desc="return help content"
   cat <<help_content
     maintenance:custom-page <app>, Imports a tarball from stdin; should contain at least maintenance.html
+    maintenance:custom-page-remove <app>, Removes a custom maintenance page and resets to the default page
     maintenance:disable <app>, Disable app maintenance mode
     maintenance:enable <app>, Enable app maintenance mode
     maintenance:report [<app>] [<flag>] [--format stdout|json], Displays a maintenance report for one or more apps

--- a/install
+++ b/install
@@ -17,6 +17,8 @@ fn-maintenance-install() {
   chown dokku:dokku "$MAINTENANCE_DATA_ROOT"
   chmod 755 "$MAINTENANCE_DATA_ROOT"
 
+  fn-plugin-property-setup "$PLUGIN_COMMAND_PREFIX"
+
   # Iterate EVERY app, unfiltered. dokku_apps "false" returns the full app list -
   # the "false" arg does not filter the set, it only suppresses the "you haven't
   # deployed any apps" error so a fresh dokku with zero apps does not abort the
@@ -29,7 +31,15 @@ fn-maintenance-install() {
       migrated=true
       APP="$app" restart_nginx "$app" || true # reload; never abort install
     fi
+    # Record a checksum for any pre-existing custom page (issue #26) so the
+    # report can expose it without a re-upload. A no-op once recorded.
+    fn-maintenance-backfill-checksum "$app" || true
   done
+
+  # The property writes above run as root; hand the store back to dokku so later
+  # (dokku-user) custom-page/report calls can read and update it.
+  local config_dir="${DOKKU_LIB_ROOT:-/var/lib/dokku}/config/$PLUGIN_COMMAND_PREFIX"
+  [[ -d "$config_dir" ]] && chown -R dokku:dokku "$config_dir"
 
   [[ "$migrated" == "true" ]] && dokku_log_verbose "Maintenance asset migration complete"
   return 0

--- a/internal-functions
+++ b/internal-functions
@@ -54,6 +54,48 @@ fn-maintenance-migrate-app() {
   return 0
 }
 
+fn-maintenance-custom-page-checksum() {
+  declare desc="canonical sha256 digest over a custom page directory's files"
+  declare DIR="$1"
+  [[ -d "$DIR" ]] || return 0
+  # Digest = sha256 of a stream of "<sha256(contents)>  <relpath>\n" lines, one
+  # per regular file, with paths relative to DIR (no ./ prefix) and C-locale
+  # sorted. Hashing the extracted content (not the tar bytes, which embed mtimes
+  # and ordering) makes the value reproducible client-side, which is what lets
+  # tooling skip redundant uploads.
+  (
+    cd "$DIR" || exit 0
+    find . -type f | sed 's|^\./||' | LC_ALL=C sort | while IFS= read -r relpath; do
+      printf '%s  %s\n' "$(sha256sum "$relpath" | cut -d' ' -f1)" "$relpath"
+    done | sha256sum | cut -d' ' -f1
+  )
+}
+
+fn-maintenance-backfill-checksum() {
+  declare desc="record a checksum for a pre-existing custom page (issue #26 upgrade path)"
+  declare APP="$1"
+  local dir="$MAINTENANCE_DATA_ROOT/$APP"
+  local page="$dir/maintenance.html"
+  local template="$MAINTENANCE_PLUGIN_ROOT/templates/maintenance.html"
+
+  # Already recorded (custom-page ran post-upgrade, or a prior backfill) - nothing to do.
+  [[ -n "$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$APP" "custom-page-sha256" "")" ]] && return 0
+  # No stored page at all - nothing to record.
+  [[ -f "$page" ]] || return 1
+
+  # A page byte-identical to the bundled default with no extra assets is the
+  # default page written by `enable`, not a custom upload - leave it unrecorded.
+  local file_count
+  file_count="$(find "$dir" -type f | wc -l)"
+  if cmp -s "$page" "$template" && [[ "$file_count" -le 1 ]]; then
+    return 1
+  fi
+
+  fn-plugin-property-write "$PLUGIN_COMMAND_PREFIX" "$APP" "custom-page-sha256" \
+    "$(fn-maintenance-custom-page-checksum "$dir")"
+  return 0
+}
+
 fn-maintenance-report-parse-args() {
   declare desc="strip --format and --global from a report invocation"
   REPORT_FORMAT="stdout"

--- a/post-delete
+++ b/post-delete
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/maintenance/config"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+fn-maintenance-post-delete() {
+  declare desc="clean up an app's maintenance assets and properties on destroy"
+  declare APP="$1"
+  [[ -z "$APP" ]] && return 0
+  fn-plugin-property-destroy "$PLUGIN_COMMAND_PREFIX" "$APP" 2>/dev/null || true
+  rm -rf "${MAINTENANCE_DATA_ROOT:?}/$APP"
+  return 0
+}
+
+fn-maintenance-post-delete "$@"

--- a/subcommands/custom-page-remove
+++ b/subcommands/custom-page-remove
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/maintenance/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-maintenance-custom-page-remove "$@"

--- a/tests/maintenance_backfill.bats
+++ b/tests/maintenance_backfill.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Covers the issue #26 install-hook backfill. On plugin install/upgrade the
+# `install` trigger records a custom-page-sha256 for any app that already has a
+# custom page, by looping over every app and calling
+# fn-maintenance-backfill-checksum. That function needs dokku's property store,
+# so we exercise it directly against a fully sandboxed data root and property
+# store (a sandbox DOKKU_LIB_ROOT) - the real host state is never touched.
+
+load 'test_helper'
+
+setup() {
+  PLUGIN_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  CORE_AVAILABLE_PATH="${PLUGIN_CORE_AVAILABLE_PATH:-/var/lib/dokku/core-plugins/available}"
+  [[ -f "$CORE_AVAILABLE_PATH/common/property-functions" ]] ||
+    skip "dokku core plugins not available at $CORE_AVAILABLE_PATH"
+  [[ -x "$CORE_AVAILABLE_PATH/common/prop" ]] ||
+    skip "dokku prop helper not available at $CORE_AVAILABLE_PATH/common/prop"
+
+  SANDBOX_DATA_ROOT="${BATS_TEST_TMPDIR}/var-www"
+  SANDBOX_LIB_ROOT="${BATS_TEST_TMPDIR}/var-lib-dokku"
+  mkdir -p "$SANDBOX_DATA_ROOT" "$SANDBOX_LIB_ROOT"
+}
+
+# Stage a stored page for $1 (name=content pairs) under the sandbox data root.
+stage_page() {
+  local app="$1"
+  shift
+  mkdir -p "$SANDBOX_DATA_ROOT/$app"
+  local pair name content
+  for pair in "$@"; do
+    name="${pair%%=*}"
+    content="${pair#*=}"
+    echo "$content" >"$SANDBOX_DATA_ROOT/$app/$name"
+  done
+}
+
+# Run a plugin function with the plugin sourced and the sandbox paths in env.
+run_fn() {
+  DOKKU_LIB_ROOT="$SANDBOX_LIB_ROOT" \
+    MAINTENANCE_DATA_ROOT="$SANDBOX_DATA_ROOT" \
+    MAINTENANCE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    PLUGIN_CORE_AVAILABLE_PATH="$CORE_AVAILABLE_PATH" \
+    run bash -c "source '$PLUGIN_ROOT/config'; source '$CORE_AVAILABLE_PATH/common/property-functions'; source '$PLUGIN_ROOT/internal-functions'; fn-plugin-property-setup maintenance >/dev/null || true; $*"
+}
+
+# Read a stored checksum back through the property store (layout-independent).
+get_property() {
+  local app="$1"
+  DOKKU_LIB_ROOT="$SANDBOX_LIB_ROOT" \
+    PLUGIN_CORE_AVAILABLE_PATH="$CORE_AVAILABLE_PATH" \
+    bash -c "source '$PLUGIN_ROOT/config'; source '$CORE_AVAILABLE_PATH/common/property-functions'; fn-plugin-property-get maintenance '$app' custom-page-sha256 ''"
+}
+
+@test "backfill records a checksum for an existing custom page" {
+  stage_page "backfill-custom" "maintenance.html=custom-marker-page" "style.css=body {}"
+
+  run_fn "fn-maintenance-backfill-checksum 'backfill-custom'"
+  [ "$status" -eq 0 ]
+
+  local expected
+  expected="$(page_checksum "$SANDBOX_DATA_ROOT/backfill-custom")"
+  [[ "$expected" =~ ^[0-9a-f]{64}$ ]]
+  [ "$(get_property backfill-custom)" = "$expected" ]
+}
+
+@test "backfill leaves the default page unrecorded" {
+  mkdir -p "$SANDBOX_DATA_ROOT/backfill-default"
+  cp "$PLUGIN_ROOT/templates/maintenance.html" "$SANDBOX_DATA_ROOT/backfill-default/maintenance.html"
+
+  run_fn "fn-maintenance-backfill-checksum 'backfill-default'"
+  [ "$status" -ne 0 ]
+  [ -z "$(get_property backfill-default)" ]
+}
+
+@test "backfill records a default-looking page that ships extra assets" {
+  mkdir -p "$SANDBOX_DATA_ROOT/backfill-extra"
+  cp "$PLUGIN_ROOT/templates/maintenance.html" "$SANDBOX_DATA_ROOT/backfill-extra/maintenance.html"
+  echo "body {}" >"$SANDBOX_DATA_ROOT/backfill-extra/style.css"
+
+  run_fn "fn-maintenance-backfill-checksum 'backfill-extra'"
+  [ "$status" -eq 0 ]
+  [ "$(get_property backfill-extra)" = "$(page_checksum "$SANDBOX_DATA_ROOT/backfill-extra")" ]
+}
+
+@test "backfill does nothing when there is no stored page" {
+  run_fn "fn-maintenance-backfill-checksum 'backfill-absent'"
+  [ "$status" -ne 0 ]
+  [ -z "$(get_property backfill-absent)" ]
+}
+
+@test "backfill is idempotent and does not overwrite an existing value" {
+  stage_page "backfill-idem" "maintenance.html=custom-marker-page"
+  run_fn "fn-maintenance-backfill-checksum 'backfill-idem'"
+  [ "$status" -eq 0 ]
+  local first
+  first="$(get_property backfill-idem)"
+  [ -n "$first" ]
+
+  # mutate the stored page, then re-run: the recorded value must not change
+  echo "changed" >>"$SANDBOX_DATA_ROOT/backfill-idem/maintenance.html"
+  run_fn "fn-maintenance-backfill-checksum 'backfill-idem'"
+  [ "$status" -eq 0 ]
+  [ "$(get_property backfill-idem)" = "$first" ]
+}

--- a/tests/maintenance_backfill.bats
+++ b/tests/maintenance_backfill.bats
@@ -15,6 +15,14 @@ setup() {
     skip "dokku core plugins not available at $CORE_AVAILABLE_PATH"
   [[ -x "$CORE_AVAILABLE_PATH/common/prop" ]] ||
     skip "dokku prop helper not available at $CORE_AVAILABLE_PATH/common/prop"
+  # The prop helper chowns the config dir it creates to the dokku system user,
+  # which only root may do when the store lives in a scratch dir. The real
+  # install trigger runs as root, so exercise this sandboxed backfill only when
+  # the suite runs as root (compose mode). Native mode runs as the unprivileged
+  # runner and already covers the same property path end-to-end through the real
+  # `dokku maintenance:custom-page`/`report` commands.
+  [[ "$(id -u)" -eq 0 ]] ||
+    skip "backfill sandbox requires root to set up the dokku property store"
 
   SANDBOX_DATA_ROOT="${BATS_TEST_TMPDIR}/var-www"
   SANDBOX_LIB_ROOT="${BATS_TEST_TMPDIR}/var-lib-dokku"

--- a/tests/maintenance_custom_page.bats
+++ b/tests/maintenance_custom_page.bats
@@ -86,3 +86,89 @@ teardown() {
   [ "$status" -eq 0 ]
   $SUDO grep -q "maintest-marker-page" "$(maintenance_page_path "$APP")"
 }
+
+@test "maintenance:custom-page records a reproducible content checksum" {
+  local stage="${BATS_TEST_TMPDIR}/page"
+  mkdir -p "$stage"
+  echo "maintest-marker-page" >"$stage/maintenance.html"
+  echo "body {}" >"$stage/style.css"
+  local tarball="${BATS_TEST_TMPDIR}/page.tar"
+  tar -cf "$tarball" -C "$stage" .
+
+  dokku maintenance:custom-page "$APP" <"$tarball"
+
+  run dokku maintenance:report "$APP" --maintenance-custom-page-sha256
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(page_checksum "$stage")" ]
+}
+
+@test "maintenance:custom-page prunes files from a previous upload" {
+  local first="${BATS_TEST_TMPDIR}/first.tar"
+  make_tarball "$first" "maintenance.html=first-page" "style.css=body {}"
+  dokku maintenance:custom-page "$APP" <"$first"
+  $SUDO test -f "$(maintenance_app_dir "$APP")/style.css"
+
+  local stage="${BATS_TEST_TMPDIR}/second"
+  mkdir -p "$stage"
+  echo "second-page" >"$stage/maintenance.html"
+  local second="${BATS_TEST_TMPDIR}/second.tar"
+  tar -cf "$second" -C "$stage" .
+  dokku maintenance:custom-page "$APP" <"$second"
+
+  # the stale asset is gone and the stored page is exactly the new upload
+  ! $SUDO test -f "$(maintenance_app_dir "$APP")/style.css"
+  run dokku maintenance:report "$APP" --maintenance-custom-page-sha256
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(page_checksum "$stage")" ]
+}
+
+@test "maintenance:custom-page-remove clears the checksum and restores the default page" {
+  dokku maintenance:enable "$APP"
+  local tarball="${BATS_TEST_TMPDIR}/custom.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page"
+  dokku maintenance:custom-page "$APP" <"$tarball"
+
+  run dokku maintenance:custom-page-remove "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Removing custom maintenance page"* ]]
+
+  # the checksum is cleared
+  run dokku maintenance:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"custom-page-sha256":""'* ]]
+
+  # the default page is served again (custom marker gone, default content back)
+  $SUDO test -f "$(maintenance_page_path "$APP")"
+  ! $SUDO grep -q "maintest-marker-page" "$(maintenance_page_path "$APP")"
+  $SUDO grep -q "Application Offline for Maintenance" "$(maintenance_page_path "$APP")"
+}
+
+@test "maintenance:custom-page-remove removes the page dir when disabled" {
+  local tarball="${BATS_TEST_TMPDIR}/custom.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page"
+  dokku maintenance:custom-page "$APP" <"$tarball"
+
+  run dokku maintenance:custom-page-remove "$APP"
+  [ "$status" -eq 0 ]
+  ! $SUDO test -d "$(maintenance_app_dir "$APP")"
+
+  run dokku maintenance:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"custom-page-sha256":""'* ]]
+}
+
+@test "maintenance:custom-page-remove is a no-op when no custom page is set" {
+  run dokku maintenance:custom-page-remove "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No custom maintenance page set"* ]]
+}
+
+@test "destroying an app removes its stored custom page (post-delete)" {
+  local tarball="${BATS_TEST_TMPDIR}/good.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page"
+  dokku maintenance:custom-page "$APP" <"$tarball"
+  $SUDO test -d "$(maintenance_app_dir "$APP")"
+
+  dokku --force apps:destroy "$APP"
+  ! $SUDO test -d "$(maintenance_app_dir "$APP")"
+}

--- a/tests/maintenance_report.bats
+++ b/tests/maintenance_report.bats
@@ -56,6 +56,40 @@ teardown() {
   [[ "$output" == *'"enabled":"true"'* ]]
 }
 
+@test "maintenance:report --format json includes an empty custom-page-sha256 by default" {
+  run dokku maintenance:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"custom-page-sha256":""'* ]]
+}
+
+@test "maintenance:report --format json includes the checksum after a custom page upload" {
+  local tarball="${BATS_TEST_TMPDIR}/good.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page"
+  dokku maintenance:custom-page "$APP" <"$tarball"
+
+  run dokku maintenance:report "$APP" --format json
+  [ "$status" -eq 0 ]
+  local sha
+  sha="$(echo "$output" | jq -r '.["custom-page-sha256"]')"
+  [[ "$sha" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "maintenance:report --maintenance-custom-page-sha256 prints just the value" {
+  local tarball="${BATS_TEST_TMPDIR}/good.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page"
+  dokku maintenance:custom-page "$APP" <"$tarball"
+
+  run dokku maintenance:report "$APP" --maintenance-custom-page-sha256
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "maintenance:report lists custom-page-sha256 among valid flags" {
+  run dokku maintenance:report "$APP" --invalid-flag
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--maintenance-custom-page-sha256"* ]]
+}
+
 @test "maintenance:report --format json rejects an info flag" {
   run dokku maintenance:report "$APP" --format json --maintenance-enabled
   [ "$status" -ne 0 ]

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -55,6 +55,19 @@ maintenance_legacy_dir() {
   echo "/home/dokku/${app}/maintenance"
 }
 
+# Reproduces the canonical custom-page checksum over a directory, matching
+# fn-maintenance-custom-page-checksum. Used to prove the reported
+# custom-page-sha256 is reproducible client-side.
+page_checksum() {
+  local dir="$1"
+  (
+    cd "$dir" || exit 0
+    find . -type f | sed 's|^\./||' | LC_ALL=C sort | while IFS= read -r f; do
+      printf '%s  %s\n' "$(sha256sum "$f" | cut -d' ' -f1)" "$f"
+    done | sha256sum | cut -d' ' -f1
+  )
+}
+
 # Builds a tarball at $1 containing the remaining arguments, given as
 # name=content pairs. Files are staged in a scratch dir under
 # $BATS_TEST_TMPDIR so bats cleans them up.


### PR DESCRIPTION
Closes #26.

`maintenance:report` now exposes a `custom-page-sha256` key holding a reproducible content checksum of an app's custom page, so declarative tooling can tell whether the stored page already matches the desired one and skip a redundant upload. The value is empty until a custom page is imported and is a canonical digest over the extracted page content rather than the uploaded tar, so a client can reproduce it locally before uploading. The checksum is recorded when a page is imported and is backfilled for any existing custom page on upgrade, importing a page now replaces the previously stored files in full, a new `maintenance:custom-page-remove` command clears the page and resets to the default, and the stored page and checksum are removed when the app is destroyed.
