### PR TITLE
feat: add maintenance:custom-page-export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ sudo dokku plugin:install https://github.com/dokku/dokku-maintenance.git mainten
 $ dokku help
     maintenance <app>                               Display the list of commands
     maintenance:custom-page <app>                   Imports a tarball from stdin; should contain at least maintenance.html
+    maintenance:custom-page-export <app>            Exports the current custom page as a tarball to stdout
     maintenance:custom-page-remove <app>            Removes a custom maintenance page and resets to the default page
     maintenance:disable <app>                       Disable app maintenance mode
     maintenance:enable <app>                        Enable app maintenance mode
@@ -85,6 +86,21 @@ You have to provide at least a maintenance.html page but you can provide images,
 
 Importing a custom page replaces the previously stored page in full, so files from an earlier upload are not left behind.
 
+Export the current custom page
+
+```
+# dokku maintenance:custom-page-export my-app > my-custom-page.tar            # Server side
+$ ssh dokku@server maintenance:custom-page-export my-app > my-custom-page.tar # Client side
+```
+
+This is the inverse of `maintenance:custom-page`: it streams the app's stored custom page to stdout as a tarball, so it can be saved or re-applied to another app or server. Piping it straight back in reproduces the same page (and the same `custom-page-sha256`):
+
+```
+$ ssh dokku@server maintenance:custom-page-export my-app | ssh dokku@other maintenance:custom-page my-app
+```
+
+If the app has no imported custom page, the command still exits successfully but emits an empty archive and prints a notice to stderr rather than the built-in default page. Because it writes a binary archive to stdout, redirect it to a file or pipe it rather than running it directly in a terminal.
+
 Remove a custom page and reset to the default
 
 ```
@@ -100,6 +116,8 @@ Removing the custom page clears the stored `custom-page-sha256`. If maintenance 
 ## custom page checksum
 
 `maintenance:report` exposes a `custom-page-sha256` key so tools that manage maintenance declaratively (for example [docket](https://github.com/dokku/docket)) can tell whether the stored page already matches the desired one and skip a redundant upload. The value is empty until a custom page is imported, and it is a checksum of the extracted page content rather than the uploaded tar (tar wrappers embed mtimes and entry ordering and are not byte-reproducible).
+
+The checksum cannot be reversed into the page itself, so to recover the actual content a remote client uses `maintenance:custom-page-export` (see [usage](#usage) above), which streams the stored page back out as a tarball. This lets a declarative tool reconstruct a server's custom maintenance page without reading the on-disk files directly.
 
 The checksum is a canonical digest over every stored file: for each regular file, sorted by its path relative to the page directory, a line of `<sha256-of-contents>  <relative-path>` is emitted, and the sha256 of that stream is the reported value. A client can reproduce it over the source directory before uploading:
 

--- a/command-functions
+++ b/command-functions
@@ -167,6 +167,41 @@ cmd-maintenance-custom-page-remove() {
   dokku_log_verbose "Done"
 }
 
+cmd-maintenance-custom-page-export() {
+  declare desc="exports the current custom page as a tarball to stdout"
+  declare cmd="maintenance:custom-page-export"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  # Support --app/$DOKKU_APP_NAME flag by reordering args into "$cmd $DOKKU_APP_NAME $@"
+  local argv=("$@")
+  [[ -n "$DOKKU_APP_NAME" ]] && set -- "$DOKKU_APP_NAME" $@
+  ##
+
+  declare APP="$1"
+  local MAINTENANCE_APP_D="$MAINTENANCE_DATA_ROOT/$APP"
+
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
+
+  # Refuse to dump a binary tar archive to an interactive terminal (the inverse
+  # of custom-page's `[[ -t 0 ]]` stdin guard); redirect it or pipe it instead.
+  [[ -t 1 ]] && dokku_log_fail "This command writes a tar archive to stdout; redirect it to a file or pipe it"
+
+  # Only a genuinely imported custom page is exportable. An empty checksum means
+  # either nothing is stored or maintenance:enable only wrote the built-in
+  # default page - neither is a customization, so emit an empty archive and note
+  # it on stderr rather than exporting page content.
+  if [[ -z "$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$APP" "custom-page-sha256" "")" ]]; then
+    dokku_log_warn "No custom maintenance page set for $APP; nothing to export"
+    tar -cf - -T /dev/null
+    return
+  fi
+
+  # Stream the stored page rooted at the page dir contents so the output can be
+  # piped straight back into `maintenance:custom-page` elsewhere.
+  tar -cf - -C "$MAINTENANCE_APP_D" .
+}
+
 cmd-maintenance-disable() {
   declare desc="take the app out of maintenance mode"
   declare cmd="maintenance:disable"

--- a/help-functions
+++ b/help-functions
@@ -28,6 +28,7 @@ fn-help-content() {
   declare desc="return help content"
   cat <<help_content
     maintenance:custom-page <app>, Imports a tarball from stdin; should contain at least maintenance.html
+    maintenance:custom-page-export <app>, Exports the current custom page as a tarball to stdout
     maintenance:custom-page-remove <app>, Removes a custom maintenance page and resets to the default page
     maintenance:disable <app>, Disable app maintenance mode
     maintenance:enable <app>, Enable app maintenance mode

--- a/subcommands/custom-page-export
+++ b/subcommands/custom-page-export
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/maintenance/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-maintenance-custom-page-export "$@"

--- a/tests/maintenance_custom_page.bats
+++ b/tests/maintenance_custom_page.bats
@@ -122,6 +122,70 @@ teardown() {
   [ "$output" = "$(page_checksum "$stage")" ]
 }
 
+@test "maintenance:custom-page-export fails when no app is specified" {
+  run dokku maintenance:custom-page-export
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Please specify an app to run the command on"* ]]
+}
+
+@test "maintenance:custom-page-export fails for a nonexistent app" {
+  run dokku maintenance:custom-page-export nonexistent-app
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"App nonexistent-app does not exist"* ]]
+}
+
+@test "maintenance:custom-page-export warns and emits an empty archive when no custom page is set" {
+  local out="${BATS_TEST_TMPDIR}/out.tar"
+  local err="${BATS_TEST_TMPDIR}/err.log"
+  # redirect the streams to files so the binary archive does not reach $output
+  run bash -c "dokku maintenance:custom-page-export '$APP' >'$out' 2>'$err'"
+  [ "$status" -eq 0 ]
+  grep -q "nothing to export" "$err"
+  # a valid but empty archive lists no entries
+  [ -z "$(tar -tf "$out")" ]
+}
+
+@test "maintenance:custom-page-export streams the stored custom page as a tarball" {
+  local tarball="${BATS_TEST_TMPDIR}/in.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page" "style.css=body {}"
+  dokku maintenance:custom-page "$APP" <"$tarball"
+
+  local out="${BATS_TEST_TMPDIR}/out.tar"
+  run bash -c "dokku maintenance:custom-page-export '$APP' >'$out'"
+  [ "$status" -eq 0 ]
+
+  local extract="${BATS_TEST_TMPDIR}/extract"
+  mkdir -p "$extract"
+  tar -xf "$out" -C "$extract"
+  grep -q "maintest-marker-page" "$extract/maintenance.html"
+  [ -f "$extract/style.css" ]
+}
+
+@test "maintenance:custom-page-export round-trips through custom-page into another app" {
+  local tarball="${BATS_TEST_TMPDIR}/in.tar"
+  make_tarball "$tarball" "maintenance.html=maintest-marker-page" "style.css=body {}"
+  dokku maintenance:custom-page "$APP" <"$tarball"
+
+  local sha1
+  sha1="$(dokku maintenance:report "$APP" --maintenance-custom-page-sha256)"
+
+  local out="${BATS_TEST_TMPDIR}/out.tar"
+  run bash -c "dokku maintenance:custom-page-export '$APP' >'$out'"
+  [ "$status" -eq 0 ]
+
+  local app2
+  app2="$(new_app_name)"
+  create_app "$app2"
+  dokku maintenance:custom-page "$app2" <"$out"
+  local sha2
+  sha2="$(dokku maintenance:report "$app2" --maintenance-custom-page-sha256)"
+  cleanup_app "$app2"
+
+  # exporting then re-importing reproduces the same content checksum
+  [[ "$sha1" =~ ^[0-9a-f]{64}$ ]]
+  [ "$sha1" = "$sha2" ]
+}
+
 @test "maintenance:custom-page-remove clears the checksum and restores the default page" {
   dokku maintenance:enable "$APP"
   local tarball="${BATS_TEST_TMPDIR}/custom.tar"

--- a/tests/maintenance_help.bats
+++ b/tests/maintenance_help.bats
@@ -8,6 +8,7 @@ load 'test_helper'
   [[ "$output" == *"Usage: dokku maintenance"* ]]
   [[ "$output" == *"Manage the maintenance mode for an app"* ]]
   [[ "$output" == *"maintenance:custom-page"* ]]
+  [[ "$output" == *"maintenance:custom-page-export"* ]]
   [[ "$output" == *"maintenance:disable"* ]]
   [[ "$output" == *"maintenance:enable"* ]]
   [[ "$output" == *"maintenance:report"* ]]


### PR DESCRIPTION
Adds the inverse of `maintenance:custom-page`, streaming the app's stored custom page back out as a tarball on stdout so it can be recovered and re-applied elsewhere. Without it, tools that reconstruct a server's declarative state cannot recover a custom maintenance page, since `maintenance:report` exposes only a checksum that cannot be reversed into the page content.

Closes #28